### PR TITLE
Create /var/run/jenkins directory if it doesn't exist yet

### DIFF
--- a/dev-util/jenkins-bin/files/init.sh
+++ b/dev-util/jenkins-bin/files/init.sh
@@ -43,6 +43,17 @@ start() {
         PARAMS="$PARAMS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/jenkins/access_log"
     fi
 
+    local piddir="${JENKINS_PIDFILE%/*}"
+    if [ ! -d "$piddir" ] ; then
+        mkdir "$piddir" && \
+        chown $RUN_AS "$piddir"
+        rc=$?
+        if [ $rc -ne 0 ]; then
+            eerror "Directory $piddir for pidfile does not exist and cannot be created"
+            return 1
+            fi
+    fi
+
     ebegin "Starting ${SVCNAME}"
     start-stop-daemon --start --quiet --background \
         --make-pidfile --pidfile $JENKINS_PIDFILE \


### PR DESCRIPTION
Without this patch, my jenkins installations don't start up automatically after reboot. This is due to the fact that the  `/var/run/jenkins` directory is missing. I have to create it manually each time I reboot the servers. This PR fixes the problem.

The code is analogue to [this](http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/dev-db/mysql-init-scripts/files/mysql-5.1.67-init.d?revision=1.1&view=markup#l67), which is the init script for mysql in the portage tree itself.