### PR TITLE
dev-vcs/hub: Add LICENSE (MIT)

### DIFF
--- a/dev-vcs/hub/hub-1.10.2.ebuild
+++ b/dev-vcs/hub/hub-1.10.2.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="http://defunkt.io/hub/"
 SRC_URI="https://github.com/${GITHUB_USER}/${GITHUB_REPO}/tarball/${GITHUB_HASH} -> ${MY_P}.tar.gz"
 
 S="${WORKDIR}/${MY_P}"
-LICENSE=""
+LICENSE="MIT"
 SLOT="0"
 
 KEYWORDS="x86 amd64"


### PR DESCRIPTION
Since the fourth day of its existence (2009-12-08), Hub has been distributed
under the MIT license [1,2].
