### PR TITLE
dev-util/jenkins-bin: Add user eclass for user/group creation.

### DIFF
--- a/dev-util/jenkins-bin/jenkins-bin-1.532.1.ebuild
+++ b/dev-util/jenkins-bin/jenkins-bin-1.532.1.ebuild
@@ -1,4 +1,4 @@
-inherit java-pkg-2 rpm
+inherit java-pkg-2 rpm user
 
 DESCRIPTION="Extensible continuous integration server"
 HOMEPAGE="http://jenkins-ci.org/"

--- a/dev-util/jenkins-bin/jenkins-bin-1.549.ebuild
+++ b/dev-util/jenkins-bin/jenkins-bin-1.549.ebuild
@@ -1,4 +1,4 @@
-inherit java-pkg-2 rpm
+inherit java-pkg-2 rpm user
 
 DESCRIPTION="Extensible continuous integration server"
 HOMEPAGE="http://jenkins-ci.org/"


### PR DESCRIPTION
user/group creation didn't work until I added the `user` eclass to the `inherit` line.
